### PR TITLE
Changed apt repo for fresh ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 wireguard_listen_port: 1194
 wireguard_interface: wg0
 wireguard_group: wireguard
+wireguard_apt_cache_valid_time: 3600

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,13 @@
 - name: Add WireGuard PPA
   apt_repository:
     repo: ppa:wireguard/wireguard
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('20.04', '<')
+
+- name: Update apt cache
+  apt:
+    update_cache: yes
+    cache_valid_time: "{{ wireguard_apt_cache_valid_time }}"
+  when: ansible_distribution == 'Ubuntu' or ansible_distribution == 'Debian'
 
 - name: Install Linux kernel headers
   apt:


### PR DESCRIPTION
Since Ubuntu 20.04, the WireGuard package has been included in the official repository:
https://packages.ubuntu.com/search?keywords=wireguard&searchon=names&suite=all&section=all

However, it didn't work for me when using a base image from a popular cloud provider. So, I added a task to update the package cache